### PR TITLE
sdkDelete doesn't block finalization if JobRun not in cancellable state

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-07-22T21:48:20Z"
-  build_hash: b2dc0f44e0b08f041de14c3944a5cc005ba97c8f
+  build_date: "2025-08-12T00:40:35Z"
+  build_hash: b4fbf4e427daaef74ed873aac01e4a9ca68fb479
   go_version: go1.24.5
-  version: v0.50.0
+  version: v0.50.0-3-gb4fbf4e
 api_directory_checksum: b3aac8d5f9f5b91ae438c9ca3fe4e905658bde01
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: f835af6f8d5aa6338537ce41dc53804c04d30a33
+  file_checksum: 9949dc8a85d6a7a97564896c261a787854640a16
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -83,6 +83,10 @@ resources:
         template_path: hooks/configuration_overrides/sdk_create_post_build_request.go.tpl
       sdk_read_one_pre_set_output:
         template_path: hooks/configuration_overrides/sdk_read_one_pre_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/job_run/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/job_run/sdk_delete_post_request.go.tpl
     exceptions:
       terminal_codes:
         - ValidationException

--- a/generator.yaml
+++ b/generator.yaml
@@ -83,6 +83,10 @@ resources:
         template_path: hooks/configuration_overrides/sdk_create_post_build_request.go.tpl
       sdk_read_one_pre_set_output:
         template_path: hooks/configuration_overrides/sdk_read_one_pre_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/job_run/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/job_run/sdk_delete_post_request.go.tpl
     exceptions:
       terminal_codes:
         - ValidationException

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.2
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1
@@ -60,11 +61,13 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/samber/lo v1.37.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/helm/templates/caches-role-binding.yaml
+++ b/helm/templates/caches-role-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "ack-emrcontainers-controller.app.fullname" . }}-namespace-caches
+  name: {{ include "ack-emrcontainers-controller.app.fullname" . }}-namespaces-cache
   labels:
     app.kubernetes.io/name: {{ include "ack-emrcontainers-controller.app.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: {{ include "ack-emrcontainers-controller.app.fullname" . }}-namespace-caches
+  name: {{ include "ack-emrcontainers-controller.app.fullname" . }}-namespaces-cache
 subjects:
 - kind: ServiceAccount
   name: {{ include "ack-emrcontainers-controller.service-account.name" . }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -205,7 +205,7 @@ spec:
             secretName: {{ .Values.aws.credentials.secretName }}
       {{- end }}
       {{- if .Values.deployment.extraVolumes }}
-        {{ toYaml .Values.deployment.extraVolumes | indent 8 }}
+        {{- toYaml .Values.deployment.extraVolumes | nindent 8 }}
       {{- end }}
       {{- end }}
   {{- with .Values.deployment.strategy }}

--- a/pkg/resource/job_run/hooks.go
+++ b/pkg/resource/job_run/hooks.go
@@ -18,6 +18,20 @@ func configurationOverridesToString(cfg *svcsdktypes.ConfigurationOverrides) (*s
 	return &configStr, nil
 }
 
+// jobInCancellableState returns whether or not the JobRun is in
+// a state where it can be cancelled.
+func jobInCancellableState(jobRun *resource) bool {
+	switch *jobRun.ko.Status.State {
+	case string(svcsdktypes.JobRunStateCompleted),
+		string(svcsdktypes.JobRunStateCancelPending),
+		string(svcsdktypes.JobRunStateCancelled),
+		string(svcsdktypes.JobRunStateFailed):
+		return false
+	default:
+		return true
+	}
+}
+
 func stringToConfigurationOverrides(cfg *string) (*svcsdktypes.ConfigurationOverrides, error) {
 	if cfg == nil {
 		cfg = aws.String("")

--- a/pkg/resource/job_run/hooks_test.go
+++ b/pkg/resource/job_run/hooks_test.go
@@ -1,0 +1,57 @@
+package job_run
+
+import (
+	"testing"
+
+	svcapitypes "github.com/aws-controllers-k8s/emrcontainers-controller/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/emrcontainers/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJobInCancellableState_NonCancellableStates(t *testing.T) {
+	nonCancellableStates := []string{
+		string(svcsdktypes.JobRunStateCompleted),
+		string(svcsdktypes.JobRunStateFailed),
+		string(svcsdktypes.JobRunStateCancelled),
+		string(svcsdktypes.JobRunStateCancelPending),
+	}
+
+	for _, state := range nonCancellableStates {
+		t.Run("state_"+state, func(t *testing.T) {
+			r := &resource{
+				ko: &svcapitypes.JobRun{
+					Status: svcapitypes.JobRunStatus{
+						State: aws.String(state),
+					},
+				},
+			}
+
+			// Verify that job is NOT in cancellable state
+			assert.False(t, jobInCancellableState(r), "Job in state %s should not be cancellable", state)
+		})
+	}
+}
+
+func TestJobInCancellableState_CancellableStates(t *testing.T) {
+	cancellableStates := []string{
+		string(svcsdktypes.JobRunStateSubmitted),
+		string(svcsdktypes.JobRunStatePending),
+		string(svcsdktypes.JobRunStateRunning),
+	}
+
+	for _, state := range cancellableStates {
+		t.Run("state_"+state, func(t *testing.T) {
+			r := &resource{
+				ko: &svcapitypes.JobRun{
+					Status: svcapitypes.JobRunStatus{
+						State: aws.String(state),
+					},
+				},
+			}
+
+			// Verify that job IS in cancellable state
+			assert.True(t, jobInCancellableState(r), "Job in state %s should be cancellable", state)
+		})
+	}
+}

--- a/pkg/resource/job_run/sdk_test.go
+++ b/pkg/resource/job_run/sdk_test.go
@@ -1,0 +1,178 @@
+package job_run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/emrcontainers"
+	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/emrcontainers/types"
+	smithy "github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	svcapitypes "github.com/aws-controllers-k8s/emrcontainers-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/runtime/pkg/metrics"
+)
+
+// resourceManager directly uses *svcsdk.Client struct instead of interface. In order to mock HTTP requests
+// we instead mock the underlying HttpClient.
+type MockHttpClient struct {
+	mock.Mock
+}
+
+func (m *MockHttpClient) Do(request *http.Request) (*http.Response, error) {
+	args := m.Called(request)
+	return args.Get(0).(*http.Response), args.Error(1)
+}
+
+// Validate that sdkDelete exits without calling CancelJobRun when JobRun is in a
+// state that isn't cancellable.
+func TestSdkDelete_NonCancellableStates_ReturnsEarlyWithoutError(t *testing.T) {
+	noncancellableStates := []string{
+		string(svcsdktypes.JobRunStateCompleted),
+		string(svcsdktypes.JobRunStateFailed),
+		string(svcsdktypes.JobRunStateCancelled),
+		string(svcsdktypes.JobRunStateCancelPending),
+	}
+
+	for _, state := range noncancellableStates {
+		t.Run("state_"+state, func(t *testing.T) {
+			r := &resource{
+				ko: &svcapitypes.JobRun{
+					Status: svcapitypes.JobRunStatus{
+						State: aws.String(state),
+						ID:    aws.String("fake-id"),
+					},
+					Spec: svcapitypes.JobRunSpec{
+						VirtualClusterID: aws.String("test-cluster-id"),
+					},
+				},
+			}
+
+			mockHttpClient := &MockHttpClient{}
+			emrClient := svcsdk.New(svcsdk.Options{
+				HTTPClient: mockHttpClient,
+				Region:     "no-region",
+			})
+
+			mockHttpClient.On("Do", mock.Anything).Return(nil, errors.New("Bad Request"))
+			rm := &resourceManager{
+				sdkapi:  emrClient,
+				metrics: metrics.NewMetrics("test-emr"),
+			}
+
+			// Execute - should return early without calling API
+			latest, err := rm.sdkDelete(context.Background(), r)
+
+			mockHttpClient.AssertNotCalled(t, "Do", mock.Anything)
+			assert.NoError(t, err)
+			assert.Nil(t, latest)
+		})
+	}
+}
+
+// Validate that when JobRun is in a cancellable state, sdkDelete calls CancelJobRun.
+func TestSdkDelete_CancellableStates_CallsCancelJobRun(t *testing.T) {
+	cancellableStates := []string{
+		string(svcsdktypes.JobRunStatePending),
+		string(svcsdktypes.JobRunStateRunning),
+		string(svcsdktypes.JobRunStateSubmitted),
+	}
+
+	for _, state := range cancellableStates {
+		t.Run("state_"+state, func(t *testing.T) {
+			r := &resource{
+				ko: &svcapitypes.JobRun{
+					Status: svcapitypes.JobRunStatus{
+						State: aws.String(state),
+						ID:    aws.String("fake-id"),
+					},
+					Spec: svcapitypes.JobRunSpec{
+						VirtualClusterID: aws.String("test-cluster-id"),
+					},
+				},
+			}
+
+			mockHttpClient := &MockHttpClient{}
+			output := svcsdk.CancelJobRunOutput{
+				Id:               r.ko.Status.ID,
+				VirtualClusterId: r.ko.Spec.VirtualClusterID,
+			}
+			jsonBytes, _ := json.Marshal(output)
+			mockHttpClient.On("Do", mock.Anything).Return(&http.Response{
+				StatusCode: 200,
+				Status:     "200 OK",
+				Body:       io.NopCloser(strings.NewReader(string(jsonBytes))),
+			}, nil)
+
+			emrClient := svcsdk.New(svcsdk.Options{
+				HTTPClient: mockHttpClient,
+				Region:     "no-region",
+			})
+			rm := &resourceManager{
+				sdkapi:  emrClient,
+				metrics: metrics.NewMetrics("test-emr"),
+			}
+
+			latest, err := rm.sdkDelete(context.Background(), r)
+
+			mockHttpClient.AssertCalled(t, "Do", mock.Anything)
+			assert.NoError(t, err)
+			assert.Nil(t, latest)
+		})
+	}
+}
+
+// Validate that in the event CancelJobRun returns a ValidationException with "Job run X is not in a cancellable state"
+// sdkDelete does not block resource finalization.
+func TestSdkDelete_ValidationErrorWithNoncancellableState_AllowsFinalization(t *testing.T) {
+	t.Run("TestSdkDelete_ValidationErrorWithNoncancellableState_AllowsFinalization", func(t *testing.T) {
+		// Create resource with cancellable state
+		state := string(svcsdktypes.JobRunStateSubmitted)
+		r := &resource{
+			ko: &svcapitypes.JobRun{
+				Status: svcapitypes.JobRunStatus{
+					State: aws.String(state),
+					ID:    aws.String("fake-id"),
+				},
+				Spec: svcapitypes.JobRunSpec{
+					VirtualClusterID: aws.String("test-cluster-id"),
+				},
+			},
+		}
+
+		mockHttpClient := &MockHttpClient{}
+		output := &smithy.GenericAPIError{
+			Message: "Job run 13221 is not in a cancellable state",
+			Code:    "ValidationException",
+			Fault:   400,
+		}
+		jsonBytes, _ := json.Marshal(output)
+		mockHttpClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: 400,
+			Status:     "400 Bad Request",
+			Body:       io.NopCloser(strings.NewReader(string(jsonBytes))),
+		}, nil)
+
+		emrClient := svcsdk.New(svcsdk.Options{
+			HTTPClient: mockHttpClient,
+			Region:     "no-region",
+		})
+		rm := &resourceManager{
+			sdkapi:  emrClient,
+			metrics: metrics.NewMetrics("test-emr"),
+		}
+
+		latest, err := rm.sdkDelete(context.Background(), r)
+
+		mockHttpClient.AssertCalled(t, "Do", mock.Anything)
+		assert.NoError(t, err)
+		assert.Nil(t, latest)
+	})
+}

--- a/templates/hooks/job_run/sdk_delete_post_request.go.tpl
+++ b/templates/hooks/job_run/sdk_delete_post_request.go.tpl
@@ -1,0 +1,10 @@
+
+// If the job has already reached a state where it has finished we can 
+// consider the delete operation completed.
+if err != nil {
+    var awsErr smithy.APIError
+    if errors.As(err, &awsErr) && awsErr.ErrorCode() == "ValidationException" && strings.HasSuffix(awsErr.ErrorMessage(), "is not in a cancellable state") {
+        rm.log.Info("JobRun is not in a cancellable state. Allowing deletion of resource continue.", "JobRun", r.ko.Status.ID)
+        return nil, nil
+    }
+}

--- a/templates/hooks/job_run/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/job_run/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,3 @@
+if !jobInCancellableState(r) {
+    return nil, nil
+}


### PR DESCRIPTION
fixes [2592](https://github.com/aws-controllers-k8s/community/issues/2592), [2594](https://github.com/aws-controllers-k8s/community/issues/2594)

Description of changes:
- sdkDelete hook to check JobRun State prior to calling CancelJobRun.
- Add post API call error handling to allow delete operation to proceed if CancelJobRun returns ValidationException for noncancellable state
- Add tests to validate new behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
