### PR TITLE
Fix ACK.Terminal state after controller upgrade

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-12-15T18:09:36Z"
-  build_hash: 5c8b9050006ef6c7d3a97c279e7b1bc163f20a0a
+  build_date: "2025-12-15T23:02:56Z"
+  build_hash: 6628671564078731ea6a83b8b0ca73ac4419159a
   go_version: go1.25.5
-  version: v0.56.0-3-g5c8b905
-api_directory_checksum: b3aac8d5f9f5b91ae438c9ca3fe4e905658bde01
+  version: v0.56.0-4-g6628671
+api_directory_checksum: d0cfbd5e7ccafa04b1e7f5b7af61b6143cc2c372
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 6ecad2fdbdc8ffff9e622ea87d354492600342e1
+  file_checksum: 861d6a2b08b8170bf31c6c2a43cea7ab483d469d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-11-29T03:34:06Z"
-  build_hash: 23c7074fa310ad1ccb38946775397c203b49f024
-  go_version: go1.25.4
-  version: v0.56.0
+  build_date: "2025-12-15T18:09:36Z"
+  build_hash: 5c8b9050006ef6c7d3a97c279e7b1bc163f20a0a
+  go_version: go1.25.5
+  version: v0.56.0-3-g5c8b905
 api_directory_checksum: b3aac8d5f9f5b91ae438c9ca3fe4e905658bde01
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 9949dc8a85d6a7a97564896c261a787854640a16
+  file_checksum: 6ecad2fdbdc8ffff9e622ea87d354492600342e1
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -76,6 +76,7 @@ resources:
         compare:
           is_ignored: true
       Tags:
+        is_immutable: true
         compare:
           is_ignored: true
     # requeue_on_success_seconds is using 15 seconds for ACK to make describe-job-run API call so that it can update fields (ex: State). This is used as default values for now until ACK enables users to configure this value using Helm charts.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -32,6 +32,8 @@ operations:
 prefix_config: {}
 resources:
   VirtualCluster:
+    update_operation:
+      custom_method_name: custom_update
     exceptions:
       terminal_codes:
         - ValidationException
@@ -71,6 +73,9 @@ resources:
         type: "string"
         is_immutable: true
         is_required: False
+        compare:
+          is_ignored: true
+      Tags:
         compare:
           is_ignored: true
     # requeue_on_success_seconds is using 15 seconds for ACK to make describe-job-run API call so that it can update fields (ex: State). This is used as default values for now until ACK enables users to configure this value using Helm charts.

--- a/apis/v1alpha1/job_run.go
+++ b/apis/v1alpha1/job_run.go
@@ -48,6 +48,7 @@ type JobRunSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	ReleaseLabel *string `json:"releaseLabel,omitempty"`
 	// The tags assigned to job runs.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	Tags map[string]*string `json:"tags,omitempty"`
 	// The virtual cluster ID for which the job run request is submitted.
 	//

--- a/config/crd/bases/emrcontainers.services.k8s.aws_jobruns.yaml
+++ b/config/crd/bases/emrcontainers.services.k8s.aws_jobruns.yaml
@@ -107,6 +107,9 @@ spec:
                   type: string
                 description: The tags assigned to job runs.
                 type: object
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               virtualClusterID:
                 description: |-
                   The virtual cluster ID for which the job run request is submitted.

--- a/config/crd/common/bases/services.k8s.aws_iamroleselectors.yaml
+++ b/config/crd/common/bases/services.k8s.aws_iamroleselectors.yaml
@@ -63,6 +63,16 @@ spec:
                 required:
                 - names
                 type: object
+              resourceLabelSelector:
+                description: LabelSelector is a label query over a set of resources.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
               resourceTypeSelector:
                 items:
                   properties:

--- a/config/crd/common/kustomization.yaml
+++ b/config/crd/common/kustomization.yaml
@@ -3,5 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - bases/services.k8s.aws_iamroleselectors.yaml
   - bases/services.k8s.aws_fieldexports.yaml
+  - bases/services.k8s.aws_iamroleselectors.yaml

--- a/generator.yaml
+++ b/generator.yaml
@@ -76,6 +76,7 @@ resources:
         compare:
           is_ignored: true
       Tags:
+        is_immutable: true
         compare:
           is_ignored: true
     # requeue_on_success_seconds is using 15 seconds for ACK to make describe-job-run API call so that it can update fields (ex: State). This is used as default values for now until ACK enables users to configure this value using Helm charts.

--- a/generator.yaml
+++ b/generator.yaml
@@ -32,6 +32,8 @@ operations:
 prefix_config: {}
 resources:
   VirtualCluster:
+    update_operation:
+      custom_method_name: custom_update
     exceptions:
       terminal_codes:
         - ValidationException
@@ -71,6 +73,9 @@ resources:
         type: "string"
         is_immutable: true
         is_required: False
+        compare:
+          is_ignored: true
+      Tags:
         compare:
           is_ignored: true
     # requeue_on_success_seconds is using 15 seconds for ACK to make describe-job-run API call so that it can update fields (ex: State). This is used as default values for now until ACK enables users to configure this value using Helm charts.

--- a/helm/crds/emrcontainers.services.k8s.aws_jobruns.yaml
+++ b/helm/crds/emrcontainers.services.k8s.aws_jobruns.yaml
@@ -107,6 +107,9 @@ spec:
                   type: string
                 description: The tags assigned to job runs.
                 type: object
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               virtualClusterID:
                 description: |-
                   The virtual cluster ID for which the job run request is submitted.

--- a/helm/crds/services.k8s.aws_iamroleselectors.yaml
+++ b/helm/crds/services.k8s.aws_iamroleselectors.yaml
@@ -63,6 +63,16 @@ spec:
                 required:
                 - names
                 type: object
+              resourceLabelSelector:
+                description: LabelSelector is a label query over a set of resources.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                required:
+                - matchLabels
+                type: object
               resourceTypeSelector:
                 items:
                   properties:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -51,6 +51,13 @@ spec:
         - "$(AWS_REGION)"
         - --aws-endpoint-url
         - "$(AWS_ENDPOINT_URL)"
+{{- if .Values.aws.identity_endpoint_url }}
+        - --aws-identity-endpoint-url
+        - "$(AWS_IDENTITY_ENDPOINT_URL)"
+{{- end }}
+{{- if .Values.aws.allow_unsafe_aws_endpoint_urls }}
+        - --allow-unsafe-aws-endpoint-urls
+{{- end }}
 {{- if .Values.log.enable_development_logging }}
         - --enable-development-logging
 {{- end }}
@@ -109,6 +116,8 @@ spec:
           value: {{ .Values.aws.region }}
         - name: AWS_ENDPOINT_URL
           value: {{ .Values.aws.endpoint_url | quote }}
+        - name: AWS_IDENTITY_ENDPOINT_URL
+          value: {{ .Values.aws.identity_endpoint_url | quote }}
         - name: ACK_WATCH_NAMESPACE
           value: {{ include "ack-emrcontainers-controller.watch-namespace" . }}
         - name: ACK_WATCH_SELECTORS

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -171,8 +171,15 @@
         "region": {
           "type": "string"
         },
-        "endpoint": {
+        "endpoint_url": {
           "type": "string"
+        },
+        "identity_endpoint_url": {
+          "type": "string"
+        },
+        "allow_unsafe_aws_endpoint_urls": {
+          "type": "boolean",
+          "default": false
         },
         "credentials": {
           "description": "AWS credentials information",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -90,6 +90,8 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
   endpoint_url: ""
+  identity_endpoint_url: ""
+  allow_unsafe_aws_endpoint_urls: false
   credentials:
     # If specified, Secret with shared credentials file to use.
     secretName: ""

--- a/pkg/resource/job_run/delta.go
+++ b/pkg/resource/job_run/delta.go
@@ -94,11 +94,6 @@ func newResourceDelta(
 			delta.Add("Spec.ReleaseLabel", a.ko.Spec.ReleaseLabel, b.ko.Spec.ReleaseLabel)
 		}
 	}
-	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
-	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
-	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VirtualClusterID, b.ko.Spec.VirtualClusterID) {
 		delta.Add("Spec.VirtualClusterID", a.ko.Spec.VirtualClusterID, b.ko.Spec.VirtualClusterID)
 	} else if a.ko.Spec.VirtualClusterID != nil && b.ko.Spec.VirtualClusterID != nil {

--- a/pkg/resource/tags/sync.go
+++ b/pkg/resource/tags/sync.go
@@ -1,0 +1,109 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags
+
+import (
+	"context"
+	"fmt"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/emrcontainers"
+)
+
+type metricsRecorder interface {
+	RecordAPICall(opType string, opID string, err error)
+}
+
+type tagsClient interface {
+	TagResource(context.Context, *svcsdk.TagResourceInput, ...func(*svcsdk.Options)) (*svcsdk.TagResourceOutput, error)
+	ListTagsForResource(context.Context, *svcsdk.ListTagsForResourceInput, ...func(*svcsdk.Options)) (*svcsdk.ListTagsForResourceOutput, error)
+	UntagResource(context.Context, *svcsdk.UntagResourceInput, ...func(*svcsdk.Options)) (*svcsdk.UntagResourceOutput, error)
+}
+
+// SyncResourceTags uses TagResource and UntagResource API Calls to add, remove
+// and update resource tags.
+func SyncResourceTags(
+	ctx context.Context,
+	client tagsClient,
+	mr metricsRecorder,
+	resourceARN string,
+	desiredTags map[string]*string,
+	latestTags map[string]*string,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("common.SyncResourceTags")
+	defer func() {
+		exit(err)
+	}()
+
+	addedOrUpdated, removed := computeTagsDelta(desiredTags, latestTags)
+
+	if len(removed) > 0 {
+		_, err = client.UntagResource(
+			ctx,
+			&svcsdk.UntagResourceInput{
+				ResourceArn: aws.String(resourceARN),
+				TagKeys:     removed,
+			},
+		)
+		mr.RecordAPICall("UPDATE", "UntagResource", err)
+		if err != nil {
+			return fmt.Errorf("UntagResource Error: %w", err)
+		}
+	}
+
+	if len(addedOrUpdated) > 0 {
+		_, err = client.TagResource(
+			ctx,
+			&svcsdk.TagResourceInput{
+				ResourceArn: aws.String(resourceARN),
+				Tags:        addedOrUpdated,
+			},
+		)
+		mr.RecordAPICall("UPDATE", "TagResource", err)
+		if err != nil {
+			return fmt.Errorf("TagResource Error: %w", err)
+		}
+	}
+	return nil
+}
+
+// computeTagsDelta compares two Tag maps and return two different list
+// containing the addedOrupdated and removed tags. The removed tags array
+// only contains the tags Keys.
+func computeTagsDelta(
+	a map[string]*string,
+	b map[string]*string,
+) (addedOrUpdated map[string]string, removed []string) {
+
+	// Find the keys in the Spec have either been added or updated.
+	addedOrUpdated = make(map[string]string)
+	for aKey, aValue := range a {
+		if bValue, exists := b[aKey]; !exists || (aValue != nil && bValue != nil && *aValue != *bValue) {
+			if aValue != nil {
+				addedOrUpdated[aKey] = *aValue
+			}
+		}
+	}
+
+	for bKey := range b {
+		if _, exists := a[bKey]; !exists {
+			removed = append(removed, bKey)
+		}
+	}
+
+	return addedOrUpdated, removed
+}

--- a/pkg/resource/tags/sync_test.go
+++ b/pkg/resource/tags/sync_test.go
@@ -1,0 +1,200 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	svcsdk "github.com/aws/aws-sdk-go-v2/service/emrcontainers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockTagsClient struct {
+	mock.Mock
+}
+
+func (m *mockTagsClient) TagResource(ctx context.Context, input *svcsdk.TagResourceInput, opts ...func(*svcsdk.Options)) (*svcsdk.TagResourceOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*svcsdk.TagResourceOutput), args.Error(1)
+}
+
+func (m *mockTagsClient) ListTagsForResource(ctx context.Context, input *svcsdk.ListTagsForResourceInput, opts ...func(*svcsdk.Options)) (*svcsdk.ListTagsForResourceOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*svcsdk.ListTagsForResourceOutput), args.Error(1)
+}
+
+func (m *mockTagsClient) UntagResource(ctx context.Context, input *svcsdk.UntagResourceInput, opts ...func(*svcsdk.Options)) (*svcsdk.UntagResourceOutput, error) {
+	args := m.Called(ctx, input)
+	return args.Get(0).(*svcsdk.UntagResourceOutput), args.Error(1)
+}
+
+type mockMetricsRecorder struct {
+	mock.Mock
+}
+
+func (m *mockMetricsRecorder) RecordAPICall(opType string, opID string, err error) {
+	m.Called(opType, opID, err)
+}
+
+func TestSyncResourceTags(t *testing.T) {
+	ctx := context.Background()
+	resourceARN := "arn:aws:emr-containers:us-west-2:123456789012:virtualclusters/test"
+
+	tests := []struct {
+		name        string
+		desired     map[string]*string
+		latest      map[string]*string
+		expectTag   bool
+		expectUntag bool
+	}{
+		{
+			name: "add new tags",
+			desired: map[string]*string{
+				"key1": aws.String("value1"),
+				"key2": aws.String("value2"),
+			},
+			latest:    map[string]*string{},
+			expectTag: true,
+		},
+		{
+			name:    "remove tags",
+			desired: map[string]*string{},
+			latest: map[string]*string{
+				"key1": aws.String("value1"),
+			},
+			expectUntag: true,
+		},
+		{
+			name: "update existing tags",
+			desired: map[string]*string{
+				"key1": aws.String("newvalue"),
+			},
+			latest: map[string]*string{
+				"key1": aws.String("oldvalue"),
+			},
+			expectTag: true,
+		},
+		{
+			name: "no changes",
+			desired: map[string]*string{
+				"key1": aws.String("value1"),
+			},
+			latest: map[string]*string{
+				"key1": aws.String("value1"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockTagsClient{}
+			mr := &mockMetricsRecorder{}
+
+			if tt.expectTag {
+				client.On("TagResource", ctx, mock.AnythingOfType("*emrcontainers.TagResourceInput")).Return(&svcsdk.TagResourceOutput{}, nil)
+				mr.On("RecordAPICall", "UPDATE", "TagResource", nil)
+			}
+
+			if tt.expectUntag {
+				client.On("UntagResource", ctx, mock.AnythingOfType("*emrcontainers.UntagResourceInput")).Return(&svcsdk.UntagResourceOutput{}, nil)
+				mr.On("RecordAPICall", "UPDATE", "UntagResource", nil)
+			}
+
+			err := SyncResourceTags(ctx, client, mr, resourceARN, tt.desired, tt.latest)
+			assert.NoError(t, err)
+
+			client.AssertExpectations(t)
+			mr.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSyncResourceTagsError(t *testing.T) {
+	ctx := context.Background()
+	resourceARN := "arn:aws:emr-containers:us-west-2:123456789012:virtualclusters/test"
+
+	client := &mockTagsClient{}
+	mr := &mockMetricsRecorder{}
+
+	desired := map[string]*string{"key1": aws.String("value1")}
+	latest := map[string]*string{}
+
+	apiError := errors.New("tag error")
+	client.On("TagResource", ctx, mock.AnythingOfType("*emrcontainers.TagResourceInput")).Return(&svcsdk.TagResourceOutput{}, apiError)
+	mr.On("RecordAPICall", "UPDATE", "TagResource", apiError)
+	expectedErr := fmt.Errorf("TagResource Error: %w", apiError)
+
+	err := SyncResourceTags(ctx, client, mr, resourceARN, desired, latest)
+	assert.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestComputeTagsDelta(t *testing.T) {
+	tests := []struct {
+		name            string
+		a               map[string]*string
+		b               map[string]*string
+		expectedAdded   map[string]string
+		expectedRemoved []string
+	}{
+		{
+			name: "add new tags",
+			a: map[string]*string{
+				"key1": aws.String("value1"),
+				"key2": aws.String("value2"),
+			},
+			b: map[string]*string{},
+			expectedAdded: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expectedRemoved: []string{},
+		},
+		{
+			name: "remove tags",
+			a:    map[string]*string{},
+			b: map[string]*string{
+				"key1": aws.String("value1"),
+			},
+			expectedAdded:   map[string]string{},
+			expectedRemoved: []string{"key1"},
+		},
+		{
+			name: "update tags",
+			a: map[string]*string{
+				"key1": aws.String("newvalue"),
+			},
+			b: map[string]*string{
+				"key1": aws.String("oldvalue"),
+			},
+			expectedAdded: map[string]string{
+				"key1": "newvalue",
+			},
+			expectedRemoved: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			added, removed := computeTagsDelta(tt.a, tt.b)
+			assert.Equal(t, tt.expectedAdded, added)
+			assert.ElementsMatch(t, tt.expectedRemoved, removed)
+		})
+	}
+}

--- a/pkg/resource/virtual_cluster/hooks.go
+++ b/pkg/resource/virtual_cluster/hooks.go
@@ -1,0 +1,54 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package virtual_cluster
+
+import (
+	"context"
+
+	"github.com/aws-controllers-k8s/emrcontainers-controller/pkg/resource/tags"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+)
+
+// custom_update handles updates for virtual clusters. Since virtual clusters
+// are immutable resources, only tag updates are supported.
+func (rm *resourceManager) custom_update(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (*resource, error) {
+	if delta.DifferentAt("Spec.Tags") {
+		if err := rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+
+	return desired, nil
+}
+
+// syncTags keeps the resource's tags in sync.
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	return tags.SyncResourceTags(
+		ctx,
+		rm.sdkapi,
+		rm.metrics,
+		string(*latest.ko.Status.ACKResourceMetadata.ARN),
+		desired.ko.Spec.Tags,
+		latest.ko.Spec.Tags,
+	)
+}

--- a/pkg/resource/virtual_cluster/sdk.go
+++ b/pkg/resource/virtual_cluster/sdk.go
@@ -292,7 +292,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	return nil, ackerr.NewTerminalError(ackerr.NotImplemented)
+	return rm.custom_update(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/test/e2e/resources/emr_virtual_cluster.yaml
+++ b/test/e2e/resources/emr_virtual_cluster.yaml
@@ -10,3 +10,9 @@ spec:
     info:
       eksInfo:
         namespace: emr-ns
+  tags:
+    Environment: dev
+    Team: data-engineering
+    Owner: finops
+
+


### PR DESCRIPTION
Issue #, if available: [2699](https://github.com/aws-controllers-k8s/community/issues/2699)

Description of changes:
After an upgrade of the emrcontainers-controller the the delta detected in `Spec.Tags` due to the change in controller version results in and ACK.Terminal state due to `sdkUpdate` not being implemented. To avoid this behavior this PR adds support for updating tags to `VirtualCluster`. Due to some additional complexity in tag support this PR simply removes `Spec.Tags` from the delta comparison for `JobRun` to avoid the change in this field from triggering an update. 

- Add support for updating tags to VirtualCluster to allow updating of tags when controller version delta detected
- Ignore JobRun Spec.Tags in delta comparison to avoid attempted update of controller version tag following upgrade of controller version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
