### PR TITLE
Add IAM Role reference to JobRun.ExecutionRoleARN

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:28:44Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
-  go_version: go1.26.2
-  version: v0.58.1
-api_directory_checksum: d0cfbd5e7ccafa04b1e7f5b7af61b6143cc2c372
+  build_date: "2026-06-22T19:08:44Z"
+  build_hash: 7bd233ce4497717ee64e21327c9d52c7c38290fe
+  go_version: go1.26.0
+  version: v0.59.1-17-g7bd233c
+api_directory_checksum: f47a018eda03c9f2282959f14fd3a85e0fe907a7
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.35.0
 generator_config_info:
-  file_checksum: 861d6a2b08b8170bf31c6c2a43cea7ab483d469d
+  file_checksum: 1e8952833a704bddb466af32fafe79454ae3c30c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -53,6 +53,10 @@ resources:
           path: Status.ID
       ExecutionRoleARN:
         is_immutable: true
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       ReleaseLabel:
         is_immutable: true
       JobDriver:

--- a/apis/v1alpha1/job_run.go
+++ b/apis/v1alpha1/job_run.go
@@ -33,7 +33,8 @@ type JobRunSpec struct {
 	//
 	// Regex Pattern: `^arn:(aws[a-zA-Z0-9-]*):iam::(\d{12})?:(role((\u002F)|(\u002F[\u0021-\u007F]+\u002F))[\w+=,.@-]+)$`
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
-	ExecutionRoleARN *string `json:"executionRoleARN,omitempty"`
+	ExecutionRoleARN *string                                  `json:"executionRoleARN,omitempty"`
+	ExecutionRoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"executionRoleRef,omitempty"`
 	// The job driver for the job run.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	JobDriver *JobDriver `json:"jobDriver,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *JobRunSpec) DeepCopyInto(out *JobRunSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ExecutionRoleRef != nil {
+		in, out := &in.ExecutionRoleRef, &out.ExecutionRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.JobDriver != nil {
 		in, out := &in.JobDriver, &out.JobDriver
 		*out = new(JobDriver)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -57,6 +58,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = iamapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/emrcontainers-controller
-  newTag: 1.3.3
+  newTag: 1.4.0

--- a/config/crd/bases/emrcontainers.services.k8s.aws_jobruns.yaml
+++ b/config/crd/bases/emrcontainers.services.k8s.aws_jobruns.yaml
@@ -65,6 +65,23 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              executionRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               jobDriver:
                 description: The job driver for the job run.
                 properties:
@@ -160,6 +177,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/config/crd/bases/emrcontainers.services.k8s.aws_virtualclusters.yaml
+++ b/config/crd/bases/emrcontainers.services.k8s.aws_virtualclusters.yaml
@@ -106,6 +106,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -45,6 +45,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - fieldexports

--- a/generator.yaml
+++ b/generator.yaml
@@ -53,6 +53,10 @@ resources:
           path: Status.ID
       ExecutionRoleARN:
         is_immutable: true
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       ReleaseLabel:
         is_immutable: true
       JobDriver:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/aws-controllers-k8s/emrcontainers-controller
 go 1.25.0
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.58.0
+	github.com/aws-controllers-k8s/iam-controller v1.7.1
+	github.com/aws-controllers-k8s/runtime v0.59.2-0.20260617181621-38bd4c967a01
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/emrcontainers v1.33.14
@@ -52,7 +53,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/micahhausler/aws-iam-policy v0.4.4 // indirect
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/aws-controllers-k8s/runtime v0.58.0 h1:PbM3hsM5z66BSPTb2CBBElYmGF3EgSbUO88efLXxL78=
-github.com/aws-controllers-k8s/runtime v0.58.0/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/iam-controller v1.7.1 h1:vr3vooNq1QXbgXe6eDJP5hxFE1sAZKSmqYM7oN9lwgU=
+github.com/aws-controllers-k8s/iam-controller v1.7.1/go.mod h1:+DkPEaeclPVtdzmaJTXgUJwylxu/3pu98/Z485VVLMA=
+github.com/aws-controllers-k8s/runtime v0.59.2-0.20260617181621-38bd4c967a01 h1:1kdTtKwkVyw5KnOt9/5b0+e3OZ55EcwTTDw9AvfnKWU=
+github.com/aws-controllers-k8s/runtime v0.59.2-0.20260617181621-38bd4c967a01/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.35.0 h1:jTPxEJyzjSuuz0wB+302hr8Eu9KUI+Zv8zlujMGJpVI=
@@ -110,8 +112,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
-github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 h1:J1D4vj3/AVzVoo1allyJJD3mh7J6bPWXVoQHOBQ+p5Y=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: emrcontainers-chart
 description: A Helm chart for the ACK service controller for Amazon EMR on EKS (EMRContainers)
-version: 1.3.3
-appVersion: 1.3.3
+version: 1.4.0
+appVersion: 1.4.0
 home: https://github.com/aws-controllers-k8s/emrcontainers-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/crds/emrcontainers.services.k8s.aws_jobruns.yaml
+++ b/helm/crds/emrcontainers.services.k8s.aws_jobruns.yaml
@@ -65,6 +65,23 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              executionRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               jobDriver:
                 description: The job driver for the job run.
                 properties:
@@ -160,6 +177,10 @@ spec:
                     description: |-
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
+                    type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
                     type: string
                   region:
                     description: Region is the AWS region in which the resource exists

--- a/helm/crds/emrcontainers.services.k8s.aws_virtualclusters.yaml
+++ b/helm/crds/emrcontainers.services.k8s.aws_virtualclusters.yaml
@@ -106,6 +106,10 @@ spec:
                       OwnerAccountID is the AWS Account ID of the account that owns the
                       backend AWS service API resource.
                     type: string
+                  partition:
+                    description: Partition is the AWS partition in which the resource
+                      exists or will exist
+                    type: string
                   region:
                     description: Region is the AWS region in which the resource exists
                       or will exist.

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/emrcontainers-controller:1.3.3".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/emrcontainers-controller:1.4.0".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -92,6 +92,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - fieldexports

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -99,6 +99,7 @@ spec:
         - "$(FEATURE_GATES)"
 {{- end }}
         - --enable-carm={{ .Values.enableCARM }}
+        - --enable-cross-namespace={{ .Values.enableCrossNamespace }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: controller

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -275,6 +275,11 @@
       "type": "boolean",
       "default": true
    },
+    "enableCrossNamespace": {
+      "description": "Enable cross-namespace behavior (resource references, secret references, field exports). When false, the controller rejects any operation that crosses namespace boundaries.",
+      "type": "boolean",
+      "default": true
+   },
     "serviceAccount": {
       "description": "ServiceAccount settings",
       "properties": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/emrcontainers-controller
-  tag: 1.3.3
+  tag: 1.4.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -175,6 +175,11 @@ leaderElection:
 
 # Enable Cross Account Resource Management (default = true). Set this to false to disable cross account resource management.
 enableCARM: true
+
+# Enable cross-namespace behavior including resource references, secret references,
+# and field exports (default = true). When false, the controller rejects any operation
+# that crosses namespace boundaries.
+enableCrossNamespace: true
 
 # Configuration for feature gates.  These are optional controller features that
 # can be individually enabled ("true") or disabled ("false") by adding key/value

--- a/pkg/resource/job_run/delta.go
+++ b/pkg/resource/job_run/delta.go
@@ -50,6 +50,9 @@ func newResourceDelta(
 			delta.Add("Spec.ExecutionRoleARN", a.ko.Spec.ExecutionRoleARN, b.ko.Spec.ExecutionRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ExecutionRoleRef, b.ko.Spec.ExecutionRoleRef) {
+		delta.Add("Spec.ExecutionRoleRef", a.ko.Spec.ExecutionRoleRef, b.ko.Spec.ExecutionRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.JobDriver, b.ko.Spec.JobDriver) {
 		delta.Add("Spec.JobDriver", a.ko.Spec.JobDriver, b.ko.Spec.JobDriver)
 	} else if a.ko.Spec.JobDriver != nil && b.ko.Spec.JobDriver != nil {

--- a/pkg/resource/job_run/identifiers.go
+++ b/pkg/resource/job_run/identifiers.go
@@ -53,3 +53,12 @@ func (ri *resourceIdentifiers) Region() *ackv1alpha1.AWSRegion {
 	}
 	return nil
 }
+
+// Partition returns the AWS partition in which the reosurce exists, or
+// nil if this information is not known.
+func (ri *resourceIdentifiers) Partition() *ackv1alpha1.AWSPartition {
+	if ri.meta != nil {
+		return ri.meta.Partition
+	}
+	return nil
+}

--- a/pkg/resource/job_run/manager.go
+++ b/pkg/resource/job_run/manager.go
@@ -75,6 +75,8 @@ type resourceManager struct {
 	awsAccountID ackv1alpha1.AWSAccountID
 	// The AWS Region that this resource manager targets
 	awsRegion ackv1alpha1.AWSRegion
+	// The AWS Partition that this resource manager targets
+	awsPartition ackv1alpha1.AWSPartition
 	// sdk is a pointer to the AWS service API client exposed by the
 	// aws-sdk-go-v2/services/{alias} package.
 	sdkapi *svcsdk.Client
@@ -193,7 +195,8 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:emrcontainers:%s:%s:%s",
+		"arn:%s:emrcontainers:%s:%s:%s",
+		rm.awsPartition,
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,
@@ -373,6 +376,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
+		awsPartition: ackv1alpha1.AWSPartition(cfg.Partition),
 		sdkapi:       svcsdk.NewFromConfig(clientcfg),
 	}, nil
 }

--- a/pkg/resource/job_run/references.go
+++ b/pkg/resource/job_run/references.go
@@ -23,12 +23,17 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/emrcontainers-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -36,6 +41,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.ExecutionRoleRef != nil {
+		ko.Spec.ExecutionRoleARN = nil
+	}
 
 	if ko.Spec.VirtualClusterRef != nil {
 		ko.Spec.VirtualClusterID = nil
@@ -60,6 +69,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForExecutionRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForVirtualClusterID(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -73,11 +88,106 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.JobRun) error {
 
+	if ko.Spec.ExecutionRoleRef != nil && ko.Spec.ExecutionRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ExecutionRoleARN", "ExecutionRoleRef")
+	}
+
 	if ko.Spec.VirtualClusterRef != nil && ko.Spec.VirtualClusterID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("VirtualClusterID", "VirtualClusterRef")
 	}
 	if ko.Spec.VirtualClusterRef == nil && ko.Spec.VirtualClusterID == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("VirtualClusterID", "VirtualClusterRef")
+	}
+	return nil
+}
+
+// resolveReferenceForExecutionRoleARN reads the resource referenced
+// from ExecutionRoleRef field and sets the ExecutionRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForExecutionRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.JobRun,
+) (hasReferences bool, err error) {
+	if ko.Spec.ExecutionRoleRef != nil && ko.Spec.ExecutionRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ExecutionRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ExecutionRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ExecutionRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
 }
@@ -97,9 +207,17 @@ func (rm *resourceManager) resolveReferenceForVirtualClusterID(
 		if arr.Name == nil || *arr.Name == "" {
 			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: VirtualClusterRef")
 		}
-		namespace := ko.ObjectMeta.GetNamespace()
-		if arr.Namespace != nil && *arr.Namespace != "" {
-			namespace = *arr.Namespace
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
 		}
 		obj := &svcapitypes.VirtualCluster{}
 		if err := getReferencedResourceState_VirtualCluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {

--- a/pkg/resource/job_run/sdk.go
+++ b/pkg/resource/job_run/sdk.go
@@ -368,6 +368,9 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.ACKResourceMetadata.Region == nil {
 		ko.Status.ACKResourceMetadata.Region = &rm.awsRegion
 	}
+	if ko.Status.ACKResourceMetadata.Partition == nil {
+		ko.Status.ACKResourceMetadata.Partition = &rm.awsPartition
+	}
 	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}

--- a/pkg/resource/virtual_cluster/identifiers.go
+++ b/pkg/resource/virtual_cluster/identifiers.go
@@ -53,3 +53,12 @@ func (ri *resourceIdentifiers) Region() *ackv1alpha1.AWSRegion {
 	}
 	return nil
 }
+
+// Partition returns the AWS partition in which the reosurce exists, or
+// nil if this information is not known.
+func (ri *resourceIdentifiers) Partition() *ackv1alpha1.AWSPartition {
+	if ri.meta != nil {
+		return ri.meta.Partition
+	}
+	return nil
+}

--- a/pkg/resource/virtual_cluster/manager.go
+++ b/pkg/resource/virtual_cluster/manager.go
@@ -75,6 +75,8 @@ type resourceManager struct {
 	awsAccountID ackv1alpha1.AWSAccountID
 	// The AWS Region that this resource manager targets
 	awsRegion ackv1alpha1.AWSRegion
+	// The AWS Partition that this resource manager targets
+	awsPartition ackv1alpha1.AWSPartition
 	// sdk is a pointer to the AWS service API client exposed by the
 	// aws-sdk-go-v2/services/{alias} package.
 	sdkapi *svcsdk.Client
@@ -193,7 +195,8 @@ func (rm *resourceManager) Delete(
 // name for the resource
 func (rm *resourceManager) ARNFromName(name string) string {
 	return fmt.Sprintf(
-		"arn:aws:emrcontainers:%s:%s:%s",
+		"arn:%s:emrcontainers:%s:%s:%s",
+		rm.awsPartition,
 		rm.awsRegion,
 		rm.awsAccountID,
 		name,
@@ -373,6 +376,7 @@ func newResourceManager(
 		rr:           rr,
 		awsAccountID: id,
 		awsRegion:    region,
+		awsPartition: ackv1alpha1.AWSPartition(cfg.Partition),
 		sdkapi:       svcsdk.NewFromConfig(clientcfg),
 	}, nil
 }

--- a/pkg/resource/virtual_cluster/sdk.go
+++ b/pkg/resource/virtual_cluster/sdk.go
@@ -340,6 +340,9 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.ACKResourceMetadata.Region == nil {
 		ko.Status.ACKResourceMetadata.Region = &rm.awsRegion
 	}
+	if ko.Status.ACKResourceMetadata.Partition == nil {
+		ko.Status.ACKResourceMetadata.Partition = &rm.awsPartition
+	}
 	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}


### PR DESCRIPTION
## Description
Add cross-resource reference from JobRun.ExecutionRoleARN to IAM Role, identified by the ACK scanner gap analysis tool.

### Changes
- **JobRun**: Add IAM Role reference to `ExecutionRoleARN` field, allowing users to reference an ACK-managed IAM Role directly

### Testing
- Code generated successfully with `make build-controller`
- Controller compiles: `go build -o bin/controller ./cmd/controller`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.